### PR TITLE
Find instance id anywhere in name

### DIFF
--- a/statsite-stackdriver
+++ b/statsite-stackdriver
@@ -101,11 +101,15 @@ function parse(metric) {
   };
 
   var segs = name.split('.');
-  if ('[' == segs[1][0]) {
-    msg.instance = segs[1].slice(1, -1);
-    segs.splice(1, 1);
-    msg.name = segs.join('.');
-  }
+
+  segs.some(function(s, i){
+    if ('[' == s[0]){
+      msg.instance = s.slice(1, -1);
+      segs.splice(i, 1);
+      msg.name = segs.join('.');
+      return true;
+    }
+  });
 
   return msg;
 }


### PR DESCRIPTION
There were 2 conditions where this was failing.
1. If instance was not the second segment in the name (I assume you had
   a single namespace prepended to each metric)
2. If there was no instance id and a simple namespace like `foo:1|c`

This should solve both of those problems. I am looping through all of
the segments to find instance info and removing that segment if it
exists.

Test Plan:

``` javascript
parse("omg|1|1234")
Object {name: "omg", value: 1, collected_at: 1234}
parse("omg.xxx|1|1234")
Object {name: "omg.xxx", value: 1, collected_at: 1234}
parse("[12345].omg.xxx|1|1234")
Object {name: "omg.xxx", value: 1, collected_at: 1234, instance: "12345"}
parse("foo.[12345].omg.xxx|1|1234")
Object {name: "foo.omg.xxx", value: 1, collected_at: 1234, instance: "12345"}
```
